### PR TITLE
Added CoC paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ with Repeated Sampling](https://arxiv.org/abs/2407.21787)
 - Tool-Integrated Reasoning (ToRA / TIR): [Paper](https://arxiv.org/abs/2309.17452)
 - Program of Thoughts (PoT): [Paper](https://arxiv.org/abs/2211.12588)
 - Buffer of Thoughts (BoT): [Paper](https://arxiv.org/abs/2406.04271)
+- Chain of Code (CoC): [Paper](https://arxiv.org/abs/2312.04474)
 
 
 ## Blog Posts


### PR DESCRIPTION
Added the Chain of Code paper to the prompting techniques section. Let me know if it should be in the LLM based agent papers section instead. Just felt like it fit better into the "Chain of X"/"X of Thought" section :D